### PR TITLE
Players only get dismounted once when they approach the alpha

### DIFF
--- a/minecraft/data/alphas/function/internal/effect/encounter.mcfunction
+++ b/minecraft/data/alphas/function/internal/effect/encounter.mcfunction
@@ -11,7 +11,7 @@ particle minecraft:flash ~ ~0.5 ~ 0 0 0 .5 1 normal @a[distance=..16]
 
 # Do a fake hit and dismount the player
 damage @p[distance=..16, tag=!cobblemon_alphas.heard_roar] 1 mob_attack by @s from @s
-ride @p dismount
+ride @p[distance=..16, tag=!cobblemon_alphas.heard_roar] dismount
 
 # Make sure that all players who saw the effect don't see it again until they walk away
 tag @a[distance=..16] add cobblemon_alphas.heard_roar


### PR DESCRIPTION
In response to issue https://github.com/WesselvanGils/CobblemonAlphas/issues/30 I have created this edit to fix the issue, while preserving the dismounting feature.